### PR TITLE
add checkCodeValue

### DIFF
--- a/src/ECPayTrait.php
+++ b/src/ECPayTrait.php
@@ -67,6 +67,7 @@ trait ECPayTrait
      */
     public function getPostData()
     {
+        $this->setCheckCodeValue();
         return $this->postData;
     }
 


### PR DESCRIPTION
由於前後分離需要由前端送出綠界資料
於是在原本 getPostData() 中加入計算 CheckMacValue
或是能另外新增一個 function 來回傳完整 postData